### PR TITLE
ntp.conf.j2: fix compatibility issue with Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 ---
 language: python
-python: "2.7"
+python:
+  - "2.7"
+  - "3.6"
 sudo: required
 install:
   - pip install ansible

--- a/templates/ntp.conf.j2
+++ b/templates/ntp.conf.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 
-{% for command, value in ntp_commands.iteritems()|sort %}
+{% for command, value in ntp_commands.items()|sort %}
 {%   if value is sameas true %}
 {{ command }}
 {%   elif value is string or value is number %}


### PR DESCRIPTION
When running the playbook, Ansible fails with :
```
failed: [xxx] (item={'src': 'ntp.conf.j2', 'dst': '/etc/ntp.conf'}) => {"changed": false, "item": {"dst": "/etc/ntp.conf", "src": "ntp.conf.j2"}, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'iteritems'"}
```
`items()` works both with Python2 and Python3

Tested with Python 3.6 and Ansible 2.5.2