### PR TITLE
Add variable to configure servers and options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ None
 
 Available variables are listed below, along with default values:
 
+    ntp_server_options: iburst
+    ntp_servers:
+      - "0.pool.ntp.org {{ ntp_server_options }}"
+      - "1.pool.ntp.org {{ ntp_server_options }}"
+      - "2.pool.ntp.org {{ ntp_server_options }}"
+      - "3.pool.ntp.org {{ ntp_server_options }}"
     ntp_commands:
       disable: monitor
       driftfile: /var/lib/ntp/drift
@@ -23,11 +29,7 @@ Available variables are listed below, along with default values:
         - default nomodify notrap nopeer noquery
         - 127.0.0.1
         - ::1
-      server:
-        - 0.pool.ntp.org iburst
-        - 1.pool.ntp.org iburst
-        - 2.pool.ntp.org iburst
-        - 3.pool.ntp.org iburst
+      server: "{{ ntp_servers }}"
     ntp_sysconfig: '-g'
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,10 @@
 ---
+ntp_server_options: iburst
+ntp_servers:
+  - "0.pool.ntp.org {{ ntp_server_options }}"
+  - "1.pool.ntp.org {{ ntp_server_options }}"
+  - "2.pool.ntp.org {{ ntp_server_options }}"
+  - "3.pool.ntp.org {{ ntp_server_options }}"
 ntp_commands:
   disable: monitor
   driftfile: /var/lib/ntp/drift
@@ -8,10 +14,6 @@ ntp_commands:
     - default nomodify notrap nopeer noquery
     - 127.0.0.1
     - ::1
-  server:
-    - 0.pool.ntp.org iburst
-    - 1.pool.ntp.org iburst
-    - 2.pool.ntp.org iburst
-    - 3.pool.ntp.org iburst
+  server: "{{ ntp_servers }}"
 ntp_sysconfig: '-g'
 ...


### PR DESCRIPTION
It is currently not possible to override the servers without
overriding the entire configuration which can result in being
different from the repo configuration.

This change introduces two new variables that can be used for
configuration:

- ntp_servers
- ntp_server_options

Their default values match the same ones that exist already
in the configuration, but it will now allow modifying the
server options and use the existing default servers, or
changing all the server config all together.